### PR TITLE
feat: add support for badges in Card component [PRO-2280]

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -47,3 +47,32 @@ code.text-\[\.9em\] {
     @apply ms-1.5 rounded-full border border-blue-200 bg-blue-100 px-1.5 text-xs font-bold text-blue-900 content-["New"];
   }
 }
+
+/* badge styles for sidebar links (content should be added manually via ::after) */
+.badge-info {
+  @apply dark:after:border-blue-200/30 dark:after:bg-blue-900/30 dark:after:text-blue-200;
+  &:after {
+    @apply ms-1.5 rounded-full border border-blue-200 bg-blue-100 px-1.5 text-xs font-bold text-blue-900;
+  }
+}
+
+.badge-success {
+  @apply dark:after:border-green-200/30 dark:after:bg-green-900/30 dark:after:text-green-200;
+  &:after {
+    @apply ms-1.5 rounded-full border border-green-200 bg-green-100 px-1.5 text-xs font-bold text-green-900;
+  }
+}
+
+.badge-danger {
+  @apply dark:after:border-red-200/30 dark:after:bg-red-900/30 dark:after:text-red-200;
+  &:after {
+    @apply ms-1.5 rounded-full border border-red-200 bg-red-100 px-1.5 text-xs font-bold text-red-900;
+  }
+}
+
+.badge-warn {
+  @apply dark:after:border-yellow-200/30 dark:after:bg-yellow-900/30 dark:after:text-yellow-200;
+  &:after {
+    @apply ms-1.5 rounded-full border border-yellow-200 bg-yellow-100 px-1.5 text-xs font-bold text-yellow-900;
+  }
+}


### PR DESCRIPTION
Add new CSS classes that style the different types of badges.

I guess we can proceed without creating a new component. Instead we’ll use CSS classes that style the different types of badges and continue using Cards.Card as before. With these updates, we’ll support four badge types: success, info, warn, and danger, each with its own style. To define the badge content (copy), you’ll need to manually add the ::after content using the syntax in the className, like so:
`after:content-['{YOUR_COPY}']`

Example how to use:
`<Cards.Card title={<span className="badge-success after:content-['New']">"lp_register_account"</span>} href="/lp/lp-api/requests#lp_register_account" />`

Result:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/d525d813-2a24-4399-98e3-32b9099b73e1" />