### PR TITLE
docs: fix small typo and fix consistency

### DIFF
--- a/app/protocol/(1-concepts)/delegation/page.mdx
+++ b/app/protocol/(1-concepts)/delegation/page.mdx
@@ -23,7 +23,7 @@ There are two important rules to understand when delegating:
 
 To delegate your FLIP tokens to an operator:
 
-1. Visit the [Delegate](https://auctions.chainflip.io/delegate) App.
+1. Visit the [Delegate App](https://auctions.chainflip.io/delegate).
 2. Connect your Ethereum wallet that contains FLIP tokens.
 3. Follow the on-screen steps to complete your delegation.
 
@@ -58,9 +58,9 @@ Delegators can withdraw their support or switch to another operator at any time,
 
 The simplest way to delegate is through your Ethereum wallet. If you already own $FLIP tokens:
 
-1. Visit the [Delegate App](https://auctions.chainflip.io/delegate)
-2. Connect your Ethereum wallet
-3. Follow the instructions to complete your delegation
+1. Visit the [Delegate App](https://auctions.chainflip.io/delegate).
+2. Connect your Ethereum wallet that contains FLIP tokens.
+3. Follow the on-screen steps to complete your delegation.
 
 ### For Operators and Validators
 
@@ -112,7 +112,7 @@ The following variables and assumptions underpin these example calculations. The
 | Self-Hosted Base RPC ($/mo)                    |   $1,700.00 |
 | Self-Hosted Validator Overhead per Node ($/mo) |      $50.00 |
 
-### Case1: Managed RPCs
+### Case 1: Managed RPCs
 
 This scenario outlines the estimated earnings and costs for Operators utilizing a managed Remote Procedure Call (RPC) service. Managed RPCs typically offer convenience and lower operational overhead but may incur higher direct service fees compared to self-hosting.
 
@@ -153,6 +153,3 @@ This scenario details the estimated economics for Operators who choose to self-h
 | **Revenue Yield Yearly**           |     39.74% |     39.74% |     39.74% |      39.74% |
 | **Net Yield Monthly**              |     -9.19% |     -1.09% |      0.53% |       1.74% |
 | **Net Yield Yearly**               |   -110.26% |    -13.12% |      6.31% |      20.88% |
-
-
-


### PR DESCRIPTION
2 identical blocks had different link styles, copied the first to the second for consistency, and a space was missing for "Case1"