### PR TITLE
Correct spacing in liquidation swaps description

### DIFF
--- a/app/lending/(1-concepts)/FAQ/page.mdx
+++ b/app/lending/(1-concepts)/FAQ/page.mdx
@@ -41,7 +41,7 @@ Loan positions are isolated; the **account** itself is unified.
 Liquidation swaps appear in the same event stream as regular scheduled swaps.
 
 There is **no special metadata** that distinguishes liquidation swaps from ordinary swaps.
-They are processed exactly the same way, and LPs are expected to price all swaps competitively,there is no need for them to know which swaps are liquidations.
+They are processed exactly the same way, and LPs are expected to price all swaps competitively, there is no need for them to know which swaps are liquidations.
 
 Large liquidations simply appear as multiple DCA-style tranches.
 


### PR DESCRIPTION
Fix spacing in the explanation of liquidation swaps.