### PR TITLE
docs: update cf-pool-depth with SqrtPrice

### DIFF
--- a/app/lp/(3-techincal-docs)/lp-node-rpcs/requests/page.mdx
+++ b/app/lp/(3-techincal-docs)/lp-node-rpcs/requests/page.mdx
@@ -174,18 +174,18 @@ Where `Range` is defined as follow:
 ```
 
 Return:
-- `asks`: UnidirectionalPoolDepth\<UnidirectionalSubPoolDepth\>
-- `bids`: UnidirectionalPoolDepth\<UnidirectionalSubPoolDepth\>
+- `asks`: UnidirectionalPoolDepth
+- `bids`: UnidirectionalPoolDepth
 
 Where `UnidirectionalPoolDepth` is defined as follows:
 ```json
 {
     "limit_orders": {
-        "price": "Option<Amount>",
+        "price": "Option<SqrtPrice>",
         "depth": "Amount",
     },
     "range_orders": {
-        "price": "Option<Amount>",
+        "price": "Option<SqrtPrice>",
         "depth": "Amount"
     }
 }


### PR DESCRIPTION
Fixing a mistake on the cf_pool_depth RPC. It has always returned a "price" as a `SqrtPrice`. not an amount or non-sqrt price.