### PR TITLE
docs: update SDK docs for v2.0.3

### DIFF
--- a/app/brokers/(2-guides)/how-to-use-chainflip-sdk/page.mdx
+++ b/app/brokers/(2-guides)/how-to-use-chainflip-sdk/page.mdx
@@ -71,7 +71,11 @@ The `options` object accepts the following properties:
 | `backendServiceUrl`(optional) | The URL of the [backend service](https://github.com/chainflip-io/chainflip-sdk-monorepo/tree/main/packages/swap). Defaults to the backend service run by Chainflip for the given network. |                  `string`                   |
 | `broker`(optional)            | The URL of the [Broker API](/brokers/running-broker-api) used for initiating swaps. Defaults to the Broker API run by Chainflip for the given network.                                    |           `` `{ url: string }` ``           |
 | `rpcUrl`(optional)            | The URL of the [Chainflip RPC node](/protocol/running-an-rpc-node). Defaults to the public rpc node operated by Chainflip for the given network.                                          |                  `String`                   |
-| `enabledFeatures`(optional)   | Features that must be explicitly opted into.                                                                                                                                              |          `` `{ dca?: boolean }` ``          |
+| `enabledFeatures`(optional)   | Features that must be explicitly opted into. `dcaV2` enables the new DCA V2 quoting strategy that returns DCA quotes for eligible swaps based on asset configuration and USD value thresholds. |          `` `{ dcaV2?: boolean }` ``          |
+
+<Callout type="warning">
+  The `dca` option in `enabledFeatures` has been deprecated and will be enabled by default in version 2.2. Use `dcaV2` for the new DCA quoting strategy.
+</Callout>
 
 ## Working Examples
 
@@ -83,7 +87,7 @@ import { SwapSDK, Chains, Assets } from "@chainflip/sdk/swap";
 // Initialize SDK
 const swapSDK = new SwapSDK({
   network: "perseverance",
-  enabledFeatures: { dca: true },
+  enabledFeatures: { dcaV2: true },
 });
 
 // Fetch quotes for swap
@@ -129,7 +133,7 @@ import { getDefaultProvider, Wallet } from "ethers";
 // Initialize SDK and Wallet
 const swapSDK = new SwapSDK({
   network: "perseverance",
-  enabledFeatures: { dca: true },
+  enabledFeatures: { dcaV2: true },
 });
 const wallet = new Wallet(
   process.env.SECRET_KEY,
@@ -189,7 +193,7 @@ import { SwapSDK, Chains, Assets } from "@chainflip/sdk/swap";
 // Initialize SDK
 const swapSDK = new SwapSDK({
   network: "perseverance",
-  enabledFeatures: { dca: true },
+  enabledFeatures: { dcaV2: true },
 });
 
 // Fetch quote for swap

--- a/app/brokers/(3-techincal-docs)/javascript-sdk/functions/page.mdx
+++ b/app/brokers/(3-techincal-docs)/javascript-sdk/functions/page.mdx
@@ -274,7 +274,7 @@ const quoteRequest = {
 };
 
 const swapSDK = new SwapSDK({
-  enabledFeatures: { dca: true }, // enable DCA feature when initiating the SDK to receive DCA quotes
+  enabledFeatures: { dcaV2: true }, // enable DCA V2 feature when initiating the SDK to receive DCA quotes
 });
 
 console.log(await swapSDK.getQuoteV2(quoteRequest));
@@ -351,6 +351,44 @@ console.log(await swapSDK.getQuoteV2(quoteRequest));
     },
   ],
 }
+```
+</details>
+
+## `calculateLivePriceSlippageTolerancePercent`
+
+Calculates the recommended slippage tolerance for live price protection. This method accounts for network fees and broker commission when computing the tolerance, ensuring swaps aren't unnecessarily refunded due to fee-related price differences.
+
+```typescript copy
+function calculateLivePriceSlippageTolerancePercent(params: {
+  srcAsset: { chain: Chain; asset: Asset };
+  destAsset: { chain: Chain; asset: Asset };
+  brokerCommissionBps?: number;
+}): Promise<number | undefined>;
+```
+
+| Param                            | Description                                                                      | Data type |
+| -------------------------------- | -------------------------------------------------------------------------------- | :-------: |
+| `srcAsset`                       | Source asset for the swap, containing chain and asset identifiers                | `Object`  |
+| `destAsset`                      | Destination asset for the swap, containing chain and asset identifiers           | `Object`  |
+| `brokerCommissionBps` (optional) | Broker commission in basis points. If provided, it will be factored into the calculation | `number`  |
+
+Returns `undefined` if live price protection is not available for the asset pair.
+
+<details>
+<summary>Example</summary>
+
+```typescript copy
+import { SwapSDK, Chains, Assets } from "@chainflip/sdk/swap";
+
+const swapSDK = new SwapSDK({ network: "mainnet" });
+
+const tolerance = await swapSDK.calculateLivePriceSlippageTolerancePercent({
+  srcAsset: { chain: Chains.Ethereum, asset: Assets.ETH },
+  destAsset: { chain: Chains.Bitcoin, asset: Assets.BTC },
+  brokerCommissionBps: 100, // 1% broker commission
+});
+
+console.log(tolerance); // e.g., 0.35
 ```
 </details>
 
@@ -581,7 +619,7 @@ const { quotes } = await swapSDK.getQuoteV2({
   amount: (1.5e18).toString(), // 1.5 ETH
 });
 
-// ❗ the DCA feature must be enabled when the SDK is instantiated to receive DCA quotes ❗
+// ❗ the dcaV2 feature must be enabled when the SDK is instantiated to receive DCA quotes ❗
 const quote = quotes.find((quote) => quote.type === "DCA");
 
 const swapDepositAddressRequest = {

--- a/app/brokers/(3-techincal-docs)/javascript-sdk/page.mdx
+++ b/app/brokers/(3-techincal-docs)/javascript-sdk/page.mdx
@@ -26,6 +26,7 @@ Here are the functions provided by the Chainflip SDK:
     <Cards.Card title="getChains" href="/brokers/javascript-sdk/functions#getchains" />
     <Cards.Card title="getAssets" href="/brokers/javascript-sdk/functions#getassets" />
     <Cards.Card title="getQuoteV2" href="/brokers/javascript-sdk/functions#getquotev2" />
+    <Cards.Card title={<span className="badge-success after:content-['New']">calculateLivePriceSlippageTolerancePercent</span>} href="/brokers/javascript-sdk/functions#calculatelivepriceslippagetolerancepercent" />
     <Cards.Card title="requestDepositAddressV2" href="/brokers/javascript-sdk/functions#requestdepositaddressv2" />
     <Cards.Card title="encodeVaultSwapData" href="/brokers/javascript-sdk/functions#encodevaultswapdata" />
     <Cards.Card title={<span className="badge-success after:content-['New']">encodeCfParameters</span>} href="/brokers/javascript-sdk/functions#encodecfparameters" />

--- a/app/brokers/(3-techincal-docs)/javascript-sdk/params/page.mdx
+++ b/app/brokers/(3-techincal-docs)/javascript-sdk/params/page.mdx
@@ -29,6 +29,7 @@ The `fillOrKillParams` object sets two different types of slippage protection wh
 | `slippageTolerancePercent`                      | The percent of slippage that is acceptable for the swap. The `estimatedPrice` field from the `quote` is used to calculate the minimum price for the channel. **This field must be left out when specifying a `minPrice`.**                                                                                           |           `string`            |
 | `minPrice`                                      | Minimum accepted price for swaps triggered through the deposit channel. **This field must be left out when specifying a `slippageTolerancePercent`.**                                                                                                                                                                |           `string`            |
 | `livePriceSlippageTolerancePercent` \(optional) | The percentage of deviation from the global index price that is acceptable for the swap to execute. If the deviation is exceeded, the swap will be refunded to the specified refund address. If not set, the default value from the `quote` will be used. Set the value to `false` to disable live price protection. | `string` `false` `undefined ` |
+| `maxOraclePriceSlippage` \(optional)            | Required when `dcaV2` is enabled and live price protection is available for both source and destination assets. This value sets the maximum acceptable slippage from the oracle price. Use `calculateLivePriceSlippageTolerancePercent` to compute an appropriate value.                                            |           `number`            |
 | `refundAddress`                                 | Address on the source chain to which the refund will be sent, if the minimum price cannot be met.                                                                                                                                                                                                                    |           `string`            |
 | `retryDurationBlocks`                           | Number of State Chain blocks after which a deposit is refunded, if the minimum price cannot be met. One State Chain block corresponds to 6 seconds.                                                                                                                                                                  |           `number`            |
 
@@ -82,6 +83,26 @@ const fillOrKillParams = {
   slippageTolerancePercent: quote.recommendedSlippageTolerancePercent, // use recommended slippage tolerance from quote
   livePriceSlippageTolerancePercent:
     quote.recommendedLivePriceSlippageTolerancePercent, // use recommended live price slippage tolerance from quote
+};
+```
+
+When using `dcaV2` with live price protection enabled for both assets:
+
+```typescript copy
+// Calculate the recommended maxOraclePriceSlippage
+const maxOraclePriceSlippage = await swapSDK.calculateLivePriceSlippageTolerancePercent({
+  srcAsset: { chain: Chains.Ethereum, asset: Assets.ETH },
+  destAsset: { chain: Chains.Bitcoin, asset: Assets.BTC },
+  brokerCommissionBps: 100,
+});
+
+const fillOrKillParams = {
+  refundAddress: "0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF",
+  retryDurationBlocks: 100,
+  slippageTolerancePercent: quote.recommendedSlippageTolerancePercent,
+  livePriceSlippageTolerancePercent:
+    quote.recommendedLivePriceSlippageTolerancePercent,
+  maxOraclePriceSlippage, // required when dcaV2 is enabled with live price protection
 };
 ```
 </details>


### PR DESCRIPTION
- Add dcaV2 option to enabledFeatures, deprecate dca option
- Document new calculateLivePriceSlippageTolerancePercent method
- Add maxOraclePriceSlippage parameter to fillOrKillParams
- Update examples to use dcaV2 instead of dca