### PR TITLE
Improve operator setup and funding guides

### DIFF
--- a/app/_meta.global.tsx
+++ b/app/_meta.global.tsx
@@ -274,7 +274,7 @@ export default {
                 title: 'Testnet',
                 items: {
                     'validator-setup': 'Validator Setup',
-                    'funding': 'Funding',
+                    'funding': 'Funding and Activation',
                     'common-problems': 'Common Problems',
                     'submitting-an-issue': 'Submitting an Issue'
                 }

--- a/app/brokers/(1-concepts)/broker-account/page.mdx
+++ b/app/brokers/(1-concepts)/broker-account/page.mdx
@@ -31,12 +31,14 @@ TODO: I would explain the various funding ways here: Smart Contract, LP.chainfli
 The easiest way to fund your Chainflip account is via the [Auctions application](https://auctions.chainflip.io/). This is primarily built for funding validator nodes, but can be used for any Chainflip account.
 
 1. Make sure you have `FLIP` (ERC-20) in your EVM crypto wallet.
-2. Go to [Chainflip Auctions page](https://auctions.chainflip.io/) > "[**My Nodes**](https://auctions.chainflip.io/nodes)".
+2. Go to [Chainflip Auctions page](https://auctions.chainflip.io)
 3. Connect your crypto wallet containing the `FLIP`.
-4. Click the button "**+ Add Node**" > You should see the "**Register new node**" dialog.
-5. Enter the Validator ID you got during [Generating Keys](/validators/mainnet/validator-setup#4-generating-validator-keys) step — your `Public Key(SS58)`— and the amount of `FLIP` you want to fund. Click on "**Add Funds**".
-6. Your crypto wallet will ask you to sign two transactions. The first one is a token approval and the second one transfers and add funds to your account.
+4. Click `Register Node`.
+5. Enter the `Validator Account ID` you got during [Generating Keys](/validators/mainnet/validator-setup#4-generating-validator-keys) step — your `Public Key(SS58)`— and the amount of `FLIP` you want to fund. Click on "**Add Funds**".
+6. Your wallet will ask you to sign two transactions. The first one is a token approval and the second one adds funds to your account.
 7. Congratulations! Your Chainflip account is now funded.
+
+> Note: The `Min. Active Bid` or `Min stake` values shown in the Auctions app are for validator bidding. They do not apply to Broker account funding.
 
 ### Fund and redeem via State Chain Gateway
 

--- a/app/brokers/(2-guides)/broker-light-rpc-node/page.mdx
+++ b/app/brokers/(2-guides)/broker-light-rpc-node/page.mdx
@@ -40,8 +40,8 @@ If you don't have a Broker account key, you can generate one using the following
 
 ```bash
 mkdir -p ./chainflip/keys/broker
-docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli chainfliplabs/chainflip-cli:berghain-1.12.0 generate-keys --json > chainflip/broker-keys.json
-cat chainflip/broker-keys.json | jq -r '.signing_key.secret_key' > chainflip/keys/broker/signing_key_file
+docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli chainfliplabs/chainflip-cli:berghain-2.1.9 generate-keys --json > chainflip/broker-keys.json
+jq -r '.signing_key.secret_key' chainflip/broker-keys.json > chainflip/keys/broker/signing_key_file
 ```
 
 ### Funding the Account
@@ -52,9 +52,15 @@ Get the public key of the Broker account:
 cat chainflip/broker-keys.json | jq -r '.signing_account_id'
 ```
 
-* Head to the [Auctions Web App](https://auctions.chainflip.io/auction)
+* Head to the [Auctions Web App](https://auctions.chainflip.io)
 
-* Click "Register Node" and follow the instructions to fund the account
+* Click *Connect Wallet* and connect a crypto wallet holding `FLIP`
+
+* Click `Register Node`, paste the Broker `signing_account_id`, then continue through the funding flow
+
+* Approve the token allowance transaction, then submit the add-funds transaction
+
+> Note: The `Min. Active Bid` or `Min stake` values shown in the Auctions app are for validator bidding. They do not apply to Broker account funding.
 
 ### Running the node
 * Start a Broker RPC node and wait for it to sync:
@@ -217,8 +223,5 @@ If you inspect the above command we achieve disk space-saving by a combination o
 * Enabling Chainflip special light-rpc sync mode using: `--sync=light-rpc`
 * Setting the number of blocks data to prune to 128 using: `--blocks-pruning=128`
 * Setting the number of blocks state data to prune to 128 using: `--state-pruning=128`
-
-
-
 
 

--- a/app/lp/(2-guides)/lp-light-rpc-node/page.mdx
+++ b/app/lp/(2-guides)/lp-light-rpc-node/page.mdx
@@ -40,21 +40,27 @@ If you don't have an LP account key, you can generate one using the following st
 
 ```bash
 mkdir -p ./chainflip/keys/lp
-docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli chainfliplabs/chainflip-cli:berghain-1.12.0 generate-keys --json > chainflip/lp-keys.json
-cat chainflip/lp-keys.json | jq -r '.signing_key.secret_key' > chainflip/keys/lp/signing_key_file
+docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli chainfliplabs/chainflip-cli:berghain-2.1.9 generate-keys --json > chainflip/lp-keys.json
+jq -r '.signing_key.secret_key' chainflip/lp-keys.json > chainflip/keys/lp/signing_key_file
 ```
 
 ### Funding the Account
 > The minimum funding amount for registering as a Broker or LP role is technically 1 FLIP. However, we recommend funding your accounts with at least 5 FLIP to account for transaction fees.
 
-Get the public key of the Broker account:
+Get the public key of the LP account:
 ```bash
 cat chainflip/lp-keys.json | jq -r '.signing_account_id'
 ```
 
-* Head to the [Auctions Web App](https://auctions.chainflip.io/auction)
+* Head to the [Auctions Web App](https://auctions.chainflip.io)
 
-* Click "Register Node" and follow the instructions to fund the account
+* Click *Connect Wallet* and connect a crypto wallet holding `FLIP`
+
+* Click `Register Node`, paste the LP `signing_account_id`, then continue through the funding flow
+
+* Approve the token allowance transaction, then submit the add-funds transaction
+
+> Note: The `Min. Active Bid` or `Min stake` values shown in the Auctions app are for validator bidding. They do not apply to LP account funding.
 
 
 ### Running the node
@@ -218,5 +224,3 @@ If you inspect the above command we achieve disk space-saving by a combination o
 * Enabling Chainflip special light-rpc sync mode using: `--sync=light-rpc`
 * Setting the number of blocks data to prune to 128 using: `--blocks-pruning=128`
 * Setting the number of blocks state data to prune to 128 using: `--state-pruning=128`
-
-

--- a/app/protocol/(3-technical-docs)/chainflip-cli/page.mdx
+++ b/app/protocol/(3-technical-docs)/chainflip-cli/page.mdx
@@ -40,14 +40,14 @@ Commands:
   get-bound-redeem-address    Shows the redeem address your account is bound to
   get-bound-executor-address  Shows the executor address your account is bound to
   register-account-role       Set your account role to the Validator, Broker, Liquidity Provider
-  rotate                      Rotate your session keys
+  rotate                      Generate validator session keys in the node keystore and register them on-chain
   stop-bidding                Stop bidding, thereby stop participating in auctions. [DEPRECATED - use \'validator
                               stop-bidding\' instead]
   start-bidding               The account starts bidding for all future auctions, until it stops bidding. [DEPRECATED -
                               use \'validator start-bidding\' instead]
   vanity-name                 Set a UTF-8 vanity name for your node (max length 64)
   pre-update-check            Check if it is safe to update your node/engine
-  generate-keys               Generates the private/public keys required needed to run a Chainflip validator node. These
+  generate-keys               Generates the private/public keys required to run a Chainflip node. For validators, these
                               are the Node Key, Ethereum Key and Validator Key. The Validator Key and Ethereum Key can
                               be recovered using the seed phrase. The Node Key does not control any funds and therefore
                               doesn\'t need to be recoverable. It is generated independently of the seed phrase

--- a/app/validators/(2-guides)/mainnet/common-problems/page.mdx
+++ b/app/validators/(2-guides)/mainnet/common-problems/page.mdx
@@ -272,11 +272,11 @@ drwxr-xr-x 5 root root 4096 Dec  7 18:34 ..
 -rw------- 1 root root   77 Jan  3 12:09 6772616e9d6d1af0f2a0ce1c0ac1faaa07c835e42d0be799bbf98dfcb7e8edb7192093df
 ```
 
-If you see any files with size 0 or any files that are not named like the ones above, then you'll need to rotate your keys by running:
+If you see any files with size 0 or any files that are not named like the ones above, then you'll need to generate and register fresh validator session keys by running:
 ```bash copy
 sudo chainflip-cli --config-root /etc/chainflip rotate
 ```
-This will take effect in the next epoch and you'll continue to miss authorship slots until then.
+This generates fresh validator session keys in the node keystore and registers them on-chain. It will take effect in the next epoch and you'll continue to miss authorship slots until then.
 
 - **System Clock is not synced**: If your system clock isn't synced with the network, then you'll miss authorship slots. The reason is that the block you are trying to author will be rejected by the network because it's timestamp is not within the allowed range. You can check your system clock by running `date` and you can sync it by running:
 ```bash copy

--- a/app/validators/(2-guides)/mainnet/funding/page.mdx
+++ b/app/validators/(2-guides)/mainnet/funding/page.mdx
@@ -46,9 +46,9 @@ sudo chainflip-cli --config-root /etc/chainflip register-account-role Validator
 
 After succesfully registering your node you should see the new node on "**My Nodes (legacy)**" page.
 
-### Rotate Keys
+### Generate and Register Session Keys
 
-Registration gives your account access to Validator-specific commands on the State Chain. The first of these is rotating and registering your authorship keys:
+Registration gives your account access to Validator-specific commands on the State Chain. The first of these is to generate validator session keys in the node keystore and register them on-chain for block authorship:
 
 ```bash copy
 sudo chainflip-cli --config-root /etc/chainflip rotate
@@ -63,7 +63,7 @@ sudo chainflip-cli --config-root /etc/chainflip validator start-bidding
 ```
 
 <Callout type="warning">
-Make sure you rotate session keys and execute the command to start bidding, otherwise you won't be able to join auctions and eventually join the active validator set.
+Make sure you generate and register your session keys, then execute the command to start bidding. Otherwise you won't be able to join auctions and eventually join the active validator set.
 </Callout>
 
 ### Set Vanity Name

--- a/app/validators/(2-guides)/mainnet/important-notes/page.mdx
+++ b/app/validators/(2-guides)/mainnet/important-notes/page.mdx
@@ -64,9 +64,9 @@ Session keys are used by the `chainflip-node` for authoring blocks and are store
 
 <Callout type="warning">
 
-It is critical to the Chainflip network that Validators back up their session keys and chaindata after each rotation. If you lose these irrecoverably, your node will miss out on up to two Epochs' worth of rewards; it won't be able to author blocks for the remainder of the current epoch; and it will be banned from the next keygen ceremony.
+It is critical to the Chainflip network that Validators back up their session keys and chaindata after each session-key rotation. If you lose these irrecoverably, your node will miss out on up to two Epochs' worth of rewards; it won't be able to author blocks for the remainder of the current epoch; and it will be banned from the next keygen ceremony.
 
-If you *do* lose your session keys irrecoverably, run `sudo chainflip-cli --config-root /etc/chainflip rotate` to generate and register a fresh key (assuming you still have access to the VPS and the data is not corrupted). However note that key cannot author blocks until the following epoch.
+If you *do* lose your session keys irrecoverably, run `sudo chainflip-cli --config-root /etc/chainflip rotate` to generate fresh validator session keys in the node keystore and register them on-chain (assuming you still have access to the VPS and the data is not corrupted). However note that the new keys cannot author blocks until the following epoch.
 
 </Callout>
 

--- a/app/validators/(2-guides)/mainnet/validator-setup/page.mdx
+++ b/app/validators/(2-guides)/mainnet/validator-setup/page.mdx
@@ -10,22 +10,16 @@ import { Callout } from "nextra/components";
 
 This is the one and only official guide for setting up your Chainflip Validator. This guide is officially maintained by the Chainflip team. For general information about the Chainflip protocol, we strongly recommend checking out the Concepts. We run both a Testnet and Mainnet, this guide helps you through setting up a validator on Mainnet. For Testnet please refer to this [guide instead](/validators/testnet/validator-setup).
 
-### Tips for Inexperienced Users
+### Before You Start
 
-If you've never used Linux before, you will need some help understanding the basics of how to set up your machine and use it. **If you feel proficient with Linux, feel free to skip this article.** For those that don't, let's clear some stuff up right away:
+This guide assumes you can:
 
-- **Do not** use your home computer (or laptop) to run a Validator unless you REALLY know what you're doing.
-- To run a Validator, you will need to **rent a server (either a Dedicated Server or a Virtual Private Server (VPS)**. There are many places to do this. You should be willing to spend **at least $50 USD** to run a server for a month.
-- To access the server from your home computer, you will need to use an SSH client. This will allow you to access the server's **command line**. Most of the validator setup you do will be through a terminal. It's _not as hard_ as it sounds but there _is_ a learning curve, and **if you can't use Google you will struggle**.
+- rent or provision an Ubuntu 22.04 server
+- connect to it over SSH
+- run commands as a user with `sudo`
+- edit configuration files in the terminal
 
-### Some Handy Tips and Resources
-
-- There are many great hosting providers out there. In no particular order, there is Hetzner, Vultr, OVH, Digital Ocean, AWS, Microsoft Azure, Kamatera, and many more. If you really have no idea what you're doing, you can follow this [guide for creating and connecting to DigitalOcean "droplets"](https://flaviocopes.com/digitalocean-create-vps/) which is just a fancy name DigitalOcean gives its VPS offering. However, be warned that DigitalOcean is more expensive than other offerings and you will need to spend upwards of $80 per month for a good server. Renting servers is pretty easy so our recommendation would be to just ask in Discord for help choosing a provider.
-- [A great guide for connecting to your server from any desktop computer using SSH](https://www.howtogeek.com/311287/how-to-connect-to-an-ssh-server-from-windows-macos-or-linux/). If you don't know how to do this **you aren't going to make it.**
-- You should know how to navigate folders using the command line. You will need to use a few commands to set up a validator, which can be googled individually as you need them. The way how changing directories and moving files work can be super confusing, so if you are stuck, try Googling what you need to do, even if it's as simple as editing a file or navigating to a directory. You'll get the hang of it. [Here's a good list of some basic commands everyone should know](https://www.lcg.ufrj.br/nodejs/books/linux-commands-handbook.pdf), many of which you'll need. **HOT TIP:** You can always hit the TAB key to autocomplete a path. For example, if there's a folder called `chainflip`, and you want to change to it, you can type `cd c` and then hit tab. Linux will autocomplete the folder or filename for you, leaving you with `cd chainflip` ready to go (there are some caveats, [but hitting the tab key never hurt anyone](https://www.youtube.com/watch?v=siaxGjttoVM))!
-- Control + C is _normally_ how copy-paste works in windows. That is **not** the case here. If you use Ctrl + C in a terminal in windows, you will force exit the program you are using. To copy content from a Terminal, highlight the text you want and right-click. Similarly, if you are trying to paste content, right-click on a blank section of the terminal. Either it will just work or a context menu will appear, allowing you to "Copy" and "Paste." This will differ depending on your operating system and SSH client. If you're stuck, ask in Discord.
-- We've tried to write the instructions so that people with minimal experience will be able to figure it out and copy-paste their way through most of it. Hopefully if you've figured out how to connect to the server's root account (or a user with sudo permissions) through SSH, you shouldn't have any showstopping problems with these docs. If you're stuck and you think there's some key information missing from these docs, please post it in the [`🙋︱help-and-support`](https://discord.com/channels/824147014140952596/824147718444023848) channel in Discord.
-- Don't forget to have fun!
+Operating a validator assumes Linux administration skills. Do not run a validator on a laptop or home machine unless you already understand the operational risks.
 
 ## 1. Prerequisites
 

--- a/app/validators/(2-guides)/testnet/common-problems/page.mdx
+++ b/app/validators/(2-guides)/testnet/common-problems/page.mdx
@@ -12,17 +12,17 @@ import { Callout } from "nextra/components";
 
 We'll continue updating this page so you can easily troubleshoot your node.
 
+This page assumes you have already worked through [Validator Setup](/validators/testnet/validator-setup) and [Funding and Activation](/validators/testnet/funding).
+
 ## How does this page work?
 
-This page is designed to help you fix all of your problems on your own!
-
-First of all you need dump recent logs from your terminal.
+Start by collecting recent logs from your node and engine:
 
 ```bash copy
 journalctl -f -u "chainflip-*"
 ```
 
-In order to quickly understand your issue, please first check if your log output resembles any of these.
+Then find the section below that best matches the symptom you are seeing.
 
 ## Not Funded
 
@@ -58,7 +58,7 @@ This can have a number of possible issues.
 Error: Failed to create EthDualRpcClient
 
 Caused by:
-    Inconsistent chain configuration. Terminating.Expected ETH chain id 5, received 1 through WebSocket., Expected ETH chain id 5, received 1 through HTTP.
+    Inconsistent chain configuration. Terminating.Expected ETH chain id 11155111, received 1 through WebSocket., Expected ETH chain id 11155111, received 1 through HTTP.
 ```
 
 ### Solution
@@ -125,6 +125,12 @@ Having a swapfile or swap partition is recommended in any case.
 Likely you haven't completed all the steps. Please start from [Generating Keys](/validators/testnet/validator-setup#4-generating-validator-keys) section and work your way very slowly, making sure you have read everything.
 
 It can be, that you did not successfully submit the `chainflip-cli` commands. Please run all the commands in [Funding and Bidding](/validators/testnet/funding#registering-and-setting-up-your-validator-node) section.
+
+Start by checking:
+
+- that your node is fully synced
+- that funding completed in the Auctions app
+- that `register-account-role`, `rotate`, and `validator start-bidding` all ran successfully
 
 #### Becoming Authority
 
@@ -272,11 +278,11 @@ drwxr-xr-x 5 root root 4096 Dec  7 18:34 ..
 -rw------- 1 root root   77 Jan  3 12:09 6772616e9d6d1af0f2a0ce1c0ac1faaa07c835e42d0be799bbf98dfcb7e8edb7192093df
 ```
 
-If you see any files with size 0 or any files that are not named like the ones above, then you'll need to rotate your keys by running:
+If you see any files with size 0 or any files that are not named like the ones above, then you'll need to generate and register fresh validator session keys by running:
 ```bash copy
 sudo chainflip-cli --config-root /etc/chainflip rotate
 ```
-This will take effect in the next epoch and you'll continue to miss authorship slots until then.
+This generates fresh validator session keys in the node keystore and registers them on-chain. It will take effect in the next epoch and you'll continue to miss authorship slots until then.
 
 - **System Clock is not synced**: If your system clock isn't synced with the network, then you'll miss authorship slots. The reason is that the block you are trying to author will be rejected by the network because it's timestamp is not within the allowed range. You can check your system clock by running `date` and you can sync it by running:
 ```bash copy

--- a/app/validators/(2-guides)/testnet/funding/page.mdx
+++ b/app/validators/(2-guides)/testnet/funding/page.mdx
@@ -1,5 +1,5 @@
 ---
-title: Funding on Testnet
+title: Funding and Activation on Testnet
 
 description: How to fund your account with the necessary amount of tFLIP on Testnet.
 ---
@@ -9,6 +9,8 @@ import { Callout } from "nextra/components";
 ## Funding & Bidding
 
 Before your Validator is considered for the active set, you must fund your account with the necessary amount of `tFLIP`.
+
+This page assumes you have already completed [Validator Setup](/validators/testnet/validator-setup), generated your keys, and started your node.
 
 <Callout type="warning">We only support MetaMask wallets currently.</Callout>
 
@@ -26,8 +28,8 @@ The current amount of `tFLIP` required to become an Active Validator can be chec
 <Callout type="info">
 **To get `tFLIP`:**
 
-- Go to our Discord.
-- Send a message containing your **Node Public Key** and you wallet address. You should have gotten this ID during the setup process in the [Generating Keys](/validators/mainnet/validator-setup#validator-keys) section of the docs.
+- Use the [Chainflip Discord support channel](https://discordapp.com/channels/824147014140952596/1025409958390550609)
+- Send a message containing your **Validator Account ID** and your wallet address. You should have gotten this ID during the setup process in the [Generating Keys](/validators/testnet/validator-setup#validator-keys) section of the docs.
 - We will send you `tFLIP` after verifying you have setup a node.
 
 </Callout>
@@ -52,7 +54,7 @@ In order to fund your account, you should use the Auctions App. You could also i
 2. Go to [Chainflip Auctions page](https://auctions.perseverance.chainflip.io/)
 3. Connect your Metamask wallet with the `tFLIP` and then go to "**My Nodes**"
 4. Click the button "**+ Add Node**" > You should see the "**Register new node**" modal
-5. Enter the Validator ID you got during [Generating Keys](/validators/mainnet/validator-setup#validator-keys) step — your `Public Key(SS58)`— and the amount of `tFLIP` you want to add funds to. Click on "**Add Funds**"
+5. Enter the **Validator Account ID** you got during [Generating Keys](/validators/testnet/validator-setup#validator-keys) — your `Public Key(SS58)`— and the amount of `tFLIP` you want to add funds to. Click on "**Add Funds**"
 6. Metamask will ask you to sign two transactions. The first one is a token approval and the second one transfers and add funds to your validator.
 7. Congratulations! You should see the new node on "**My Nodes**" page
 8. Once you have successfully funded your account, jump back to your terminal and run the following:
@@ -97,17 +99,30 @@ sudo chainflip-cli --config-root /etc/chainflip register-account-role Validator
 
 If everything worked, you should see a transaction hash, also known as an 'extrinsic hash,' displayed on your terminal by the CLI. Congratulations! You just submitted a transaction to the Chainflip State Chain! You can go and check on it by copying the extrinsic hash and pasting it into [https://scan.perseverance.chainflip.io/](https://scan.perseverance.chainflip.io/).
 
-Registration gives your account access to Validator-specific commands on the State Chain. The first of these is rotating and registering your authorship keys:
+Registration gives your account access to Validator-specific commands on the State Chain. The first of these is to generate validator session keys in the node keystore and register them on-chain for block authorship:
 
 ```bash copy
 sudo chainflip-cli --config-root /etc/chainflip rotate
 ```
+
+If this succeeds, you should again see an extrinsic hash in the terminal.
 
 Now your node should be synced, your account be fully registered, your ports open, your Chainflip Engine humming along. Check the logs once more, check your node status in the web app, then crack your knuckles one more time and signal your intent to bid in the next auction:
 
 ```bash copy
 sudo chainflip-cli --config-root /etc/chainflip validator start-bidding
 ```
+
+If this succeeds, open the Auctions app, look under `Current Auction State`, disable `Hide unqualified nodes`, and search for your node ID in the search box. Your node should appear with the `Bidding` label. After the next rotation, a healthy node should move toward `Backup` / `Qualified`, and later `Authority` if selected.
+
+### Expected Validator States
+
+After completing the steps on this page, the Auctions app should typically move through these states:
+
+- `Offline`: the node is not fully funded, synced, or registered yet
+- `Bidding`: the validator is participating in auctions
+- `Backup` / `Qualified`: the validator is healthy and eligible, but not currently selected as an authority
+- `Authority`: the validator has been selected into the active set
 
 **Optionally**, you can set a Vanity Name for your validator by running:
 
@@ -121,6 +136,8 @@ sudo chainflip-cli --config-root /etc/chainflip vanity-name <my-discord-username
 ```
 
 Once the Auction cycle is complete, the network will attempt to include your node in the next Key generation ceremony, and if successful, you'll be a real Authority! Remember you can always add more `tFLIP` to have a better chance at winning an Auction.
+
+If your validator does not move into the expected state, continue to [Common Problems on Testnet](/validators/testnet/common-problems).
 
 ## Rebalancing
 

--- a/app/validators/(2-guides)/testnet/submitting-an-issue/page.mdx
+++ b/app/validators/(2-guides)/testnet/submitting-an-issue/page.mdx
@@ -10,6 +10,15 @@ description: This is the official way to report an issue on Testnet
 
 This is the official way to report an issue.
 
+Use this page only after you have already checked [Common Problems on Testnet](/validators/testnet/common-problems).
+
+Before opening an issue, collect:
+
+- your Validator Account ID
+- the current node status you see in the Auctions app
+- the last command you ran and its output
+- recent `chainflip-node` / `chainflip-engine` logs
+
 First output your logs to the terminal. Copy the output to the channel below.
 
 ```bash copy

--- a/app/validators/(2-guides)/testnet/validator-setup/page.mdx
+++ b/app/validators/(2-guides)/testnet/validator-setup/page.mdx
@@ -10,27 +10,30 @@ import { Callout } from "nextra/components";
 
 This is the one and only official guide for setting up your Chainflip Validator. This guide is officially maintained by the Chainflip team. For general information about the Chainflip protocol, we strongly recommend checking out the Concepts. We run both a Testnet and Mainnet, this guide helps you through setting up a validator on Testnet. For Mainnet please refer to this [guide instead](/validators/mainnet/validator-setup).
 
-### Tips for Inexperienced Users
+### Before You Start
 
-If you've never used Linux before, you will need some help understanding the basics of how to set up your machine and use it. **If you feel proficient with Linux, feel free to skip this article.** For those that don't, let's clear some stuff up right away:
+This guide assumes you can:
 
-- **Do not** use your home computer (or laptop) to run a Validator unless you REALLY know what you're doing.
-- To run a Validator, you will need to **rent a server (either a Dedicated Server or a Virtual Private Server (VPS)**. There are many providers to choose from. You should be willing to spend **at least $50 USD** to run a server for a month.
-- To access the server from your home computer, you will need to use an SSH client. This will allow you to access the server's **command line**. Most of the validator setup you do will be through a terminal. It's _not as hard_ as it sounds but there _is_ a learning curve, and **if you can't use web search or AI assistants you will struggle**.
-- If all of this sounds too much to you, there's only one way to find out if you can do it: give it a go! We would never recommend that inexperienced users risk their funds by running a mainnet node themselves, but seeing as it's a testnet, **here's your chance to learn more about how Linux and blockchain infrastructure works under the hood.** Having said that, we recommend getting a bit familiar with how Linux command line works before starting this guide.
+- rent or provision an Ubuntu 22.04 server
+- connect to it over SSH
+- run commands as a user with `sudo`
+- edit configuration files in the terminal
 
-### Some Handy Tips and Resources
-
-- There are many great hosting providers out there. In no particular order, there is Hetzner, Vultr, OVH, Digital Ocean, AWS, Microsoft Azure, Kamatera, and many more. If you really have no idea what you're doing, you can follow this [guide for creating and connecting to DigitalOcean "droplets"](https://flaviocopes.com/digitalocean-create-vps/) which is just a fancy name DigitalOcean gives its VPS offering. However, be warned that DigitalOcean is more expensive than other offerings and you will need to spend upwards of $80 per month for a good server. Renting servers is pretty easy so our recommendation would be to just ask in our Discord for help choosing a provider.
-- [A great guide for connecting to your server from any desktop computer using SSH](https://www.howtogeek.com/311287/how-to-connect-to-an-ssh-server-from-windows-macos-or-linux/). If you don't know how to do this **you aren't going to make it.**
-- You should know how to navigate folders using the command line. You will need to use a few commands to set up a validator, which can be googled individually as you need them. The way how changing directories and moving files work can be super confusing, so if you are stuck, try Googling what you need to do, even if it's as simple as editing a file or navigating to a directory. You'll get the hang of it. [Here's a good list of some basic commands everyone should know](https://www.lcg.ufrj.br/nodejs/books/linux-commands-handbook.pdf), many of which you'll need. **HOT TIP:** You can always hit the TAB key to autocomplete a path. For example, if there's a folder called `chainflip`, and you want to change to it, you can type `cd c` and then hit tab. Linux will autocomplete the folder or filename for you, leaving you with `cd chainflip` ready to go (there are some caveats, [but hitting the tab key never hurt anyone](https://www.youtube.com/watch?v=siaxGjttoVM))!
-- Control + C is _normally_ how copy-paste works in windows. That is **not** the case here. If you use Ctrl + C in a terminal in windows, you will force exit the program you are using. To copy content from a Terminal, highlight the text you want and right-click. Similarly, if you are trying to paste content, right-click on a blank section of the terminal. Either it will just work or a context menu will appear, allowing you to "Copy" and "Paste." This will differ depending on your operating system and SSH client. If you're stuck, ask in Discord.
-- We've tried to write the instructions so that people with minimal experience will be able to figure it out and copy-paste their way through most of it. Hopefully if you've figured out how to connect to the server's root account (or a user with sudo permissions) through SSH, you shouldn't have any showstopping problems with these docs. If you're stuck and you think there's some key information missing from these docs, please post it in the [`🙋︱help-and-support`](https://discord.com/channels/824147014140952596/824147718444023848) channel in Discord.
-- Don't forget to have fun!
+Operating a validator assumes Linux administration skills. Do not run a validator on a laptop or home machine unless you already understand the operational risks.
 
 ## 1. Prerequisites
 
 This section describes what you are going to need to successfully set up a Chainflip validator node.
+
+### Testnet Validator Flow
+
+At a high level, the setup process is:
+
+1. Install the Chainflip binaries and download chaindata.
+2. Generate your validator keys.
+3. Fund your Validator Account ID with `tFLIP`.
+4. Register the Validator role and session keys on-chain.
+5. Start bidding and wait for the next rotation.
 
 ### Ethereum Accounts
 
@@ -38,8 +41,9 @@ We highly advise **against** using a digital wallet that has any real funds in t
 
 You'll need two Ethereum Accounts:
 
-1. The first one (we will refer to it as (_**your**_ _**Wallet/Account**_) will be used for receiving `tFLIP` and Interacting with the Auctions App to add and redeem funds.
+1. The first one (we will refer to it as (_**your**_ _**Wallet/Account**_) will be used for receiving `tFLIP` and interacting with the Auctions App to add and redeem funds. In practice, you fund the validator from your own wallet in the Auctions app. Those funds are used to bid for a place in the authority set and, if selected, become part of the validator bond, which can be slashed for validator faults and protocol offences.
 2. The second one (we will refer to it as the (_**Validator Wallet/Account**_) will be used by the validator to send transactions to the Sepolia Ethereum blockchain (this will be automatically generated as part of [Generating Keys](#validator-keys)).
+The Validator Wallet is the Ethereum wallet generated by `chainflip-cli` to pay gas fees.
 
 **sETH (Sepolia Ether)**
 
@@ -432,6 +436,8 @@ Copy the following to your `nano` editor. You also need to replace `IP_ADDRESS_O
 
 Also you'll need to provide the `eth.rpc.ws_endpoint`, `eth.rpc.http_endpoint`, `arb.rpc.ws_endpoint`, and `arb.rpc.http_endpoint` for whichever [Ethereum client](#pointing-to-the-ethereum-client) and [Arbitrum client](#pointing-to-the-arbitrum-client) you've selected. It will look different depending on which client you select:
 
+If you use a hosted RPC provider such as Alchemy, Infura, or Rivet, create a Sepolia app for Ethereum and an Arbitrum Sepolia app for Arbitrum in that provider's dashboard, then copy the HTTPS and WebSocket URLs it gives you.
+
 **Ethereum**
 
 - Rivet - `wss://SOME_LONG_SECRET_INFORMATION.sepolia.ws.rivet.cloud`
@@ -473,6 +479,7 @@ signing_key_file = "/etc/chainflip/keys/signing_key_file"
 private_key_file = "/etc/chainflip/keys/ethereum_key_file"
 
 [eth.rpc]
+# Replace these example values with your own endpoints.
 ws_endpoint = "wss://my_local_eth_node:8546"
 http_endpoint = "https://my_local_eth_node:8545"
 
@@ -502,6 +509,7 @@ http_endpoint = "http://my_local_btc_node:8332"
 private_key_file = "/etc/chainflip/keys/ethereum_key_file"
 
 [arb.rpc]
+# Replace these example values with your own endpoints.
 ws_endpoint = "ws://my_local_arbitrum_node:8548"
 http_endpoint = "http://my_local_arbitrum_node:8547"
 
@@ -592,6 +600,8 @@ systemctl status chainflip-node
 </Callout>
 
 At this point, you will need to wait for your node to catch up with the latest block. You can find the latest block on our [Block Explorer.](https://scan.perseverance.chainflip.io)
+
+With the snapshot, this usually takes minutes rather than hours. Your node is close to synced when the block number in your logs is close to the latest block on the explorer and the rapid catch-up messages slow down.
 
 <Callout type="warning">
     If you try to start your engine now it **will crash**. Wait for your node to sync before proceeding.
@@ -720,3 +730,14 @@ sudo systemctl enable chainflip-engine
     Anytime you make changes to your config file, don't forget to run:
     `systemctl restart chainflip-engine`
 </Callout>
+
+## Next Step
+
+At this point you should have:
+
+- a synced or syncing node
+- a generated `Validator Account ID`
+- a validator Ethereum wallet with enough `sETH` to pay gas fees
+- both `chainflip-node` and `chainflip-engine` running
+
+Next, continue to [Funding and Activation on Testnet](/validators/testnet/funding) to fund the validator, register its role, generate session keys, and start bidding.


### PR DESCRIPTION
- Fix incorrect Auctions links and UI wording
- Replace outdated  `Add Node` references with `Register Node`
- remove too beginner terminal tips
- clarify validator setup, funding, session-key and bidding flow
- improve testnet guide handoffs, status expectations and troubleshooting context
- update Broker/LP key-generation and funding instructions