### PR TITLE
chore: update arbitrum ingress safety margin.

### DIFF
--- a/app/protocol/(1-concepts)/ingress-witnessing-deposits/page.mdx
+++ b/app/protocol/(1-concepts)/ingress-witnessing-deposits/page.mdx
@@ -39,7 +39,7 @@ The safety margin varies by chain. Some chains, like Polkadot, have deterministi
 |----------|--------------------|----------------|
 |Bitcoin   |                   2| ~10 min        |
 |Ethereum  |                   5| ~12 sec        |
-|Arbitrum  |                   2| ~0.26 sec      |
+|Arbitrum  |               49-72| ~0.26 sec      |
 |Polkadot  |                   -| ~6 sec         |
 |Solana    |  finalized (~12sec)| ~0.4 sec       |
 |Tron      |                  19| ~3 sec         |


### PR DESCRIPTION
I've updated the safety-margin to the new value. It looks like it was a bit off before because what is counted as an "arbitrum block" on the state-chain is actually a batch of 24 arbitrum blocks in reality. The new numbers adjust for this + the incoming mainnet change.